### PR TITLE
IDA pro compatibility tweaks

### DIFF
--- a/IDA_scripts/IDA_acfg_disasm/IDA_acfg_disasm.py
+++ b/IDA_scripts/IDA_acfg_disasm/IDA_acfg_disasm.py
@@ -205,7 +205,7 @@ def get_basic_blocks(fva):
 
 def get_bb_disasm(bb, md, prefix):
     """Return the (nomalized) disassembly for a BasicBlock."""
-    b64_bytes = base64.b64encode(idc.get_bytes(bb.va, bb.size))
+    b64_bytes = base64.b64encode(idc.get_bytes(bb.va, bb.size)).decode()
     bb_heads, bb_mnems, bb_disasm, bb_norm = \
         capstone_disassembly(md, bb.va, bb.size, prefix)
     return b64_bytes, bb_heads, bb_mnems, bb_disasm, bb_norm
@@ -280,12 +280,12 @@ def run_acfg_disasm(idb_path, fva_list, output_dir):
 if __name__ == '__main__':
     if not idaapi.get_plugin_options("acfg_disasm"):
         print("[!] -Oacfg_disasm option is missing")
-        idc.Exit(1)
+        idaapi.qexit(1)
 
     plugin_options = idaapi.get_plugin_options("acfg_disasm").split(":")
     if len(plugin_options) != 3:
         print("[!] -Oacfg_disasm:INPUT_JSON:IDB_PATH:OUTPUT_DIR is required")
-        idc.Exit(1)
+        idaapi.qexit(1)
 
     input_json = plugin_options[0]
     idb_path = plugin_options[1]
@@ -296,10 +296,10 @@ if __name__ == '__main__':
 
     if idb_path not in selected_functions:
         print("[!] Error! IDB path (%s) not in %s" % (idb_path, input_json))
-        idc.Exit(1)
+        idaapi.qexit(1)
 
     fva_list = selected_functions[idb_path]
     print("[D] Found %d addresses" % len(fva_list))
 
     run_acfg_disasm(idb_path, fva_list, output_dir)
-    idc.Exit(0)
+    idaapi.qexit(0)

--- a/IDA_scripts/IDA_acfg_disasm/test_acfg_disasm.py
+++ b/IDA_scripts/IDA_acfg_disasm/test_acfg_disasm.py
@@ -41,13 +41,20 @@ from click.testing import CliRunner
 
 class TestIDAAcfgDisasm(unittest.TestCase):
 
+    maxDiff = None
+
     def remove_elaspesed_time(self, jd):
         """Elapsed time will be different in any run."""
         for idb, addr in jd.items():
             for va in addr:
-                if isinstance(jd[idb][va], dict) \
-                        and 'elapsed_time' in jd[idb][va]:
+                if not isinstance(jd[idb][va], dict):
+                    continue
+                if 'elapsed_time' in jd[idb][va]:
                     jd[idb][va]['elapsed_time'] = -1
+                if 'nodes' in jd[idb][va]:
+                    jd[idb][va]['nodes'] = sorted(jd[idb][va]['nodes'])
+                if 'edges' in jd[idb][va]:
+                    jd[idb][va]['edges'] = sorted(jd[idb][va]['edges'])
         return jd
 
     def test_acfg_disasm(self):

--- a/IDA_scripts/IDA_acfg_disasm/test_large_acfg_disasm.py
+++ b/IDA_scripts/IDA_acfg_disasm/test_large_acfg_disasm.py
@@ -41,13 +41,20 @@ from click.testing import CliRunner
 
 class TestIDAAcfgDisasm(unittest.TestCase):
 
+    maxDiff = None
+
     def remove_elaspesed_time(self, jd):
         """Elapsed time will be different in any run."""
         for idb, addr in jd.items():
             for va in addr:
-                if isinstance(jd[idb][va], dict) \
-                        and 'elapsed_time' in jd[idb][va]:
+                if not isinstance(jd[idb][va], dict):
+                    continue
+                if 'elapsed_time' in jd[idb][va]:
                     jd[idb][va]['elapsed_time'] = -1
+                if 'nodes' in jd[idb][va]:
+                    jd[idb][va]['nodes'] = sorted(jd[idb][va]['nodes'])
+                if 'edges' in jd[idb][va]:
+                    jd[idb][va]['edges'] = sorted(jd[idb][va]['edges'])
         return jd
 
     def test_acfg_disasm_large(self):

--- a/IDA_scripts/IDA_acfg_features/IDA_acfg_features.py
+++ b/IDA_scripts/IDA_acfg_features/IDA_acfg_features.py
@@ -273,12 +273,12 @@ def run_acfg_features(idb_path, fva_list, output_dir):
 if __name__ == '__main__':
     if not idaapi.get_plugin_options("acfg_features"):
         print("[!] -Oacfg_features option is missing")
-        idc.Exit(1)
+        idaapi.qexit(1)
 
     plugin_options = idaapi.get_plugin_options("acfg_features").split(":")
     if len(plugin_options) != 3:
         print("[!] -Oacfg_features:INPUT_JSON:IDB_PATH:OUTPUT_DIR is required")
-        idc.Exit(1)
+        idaapi.qexit(1)
 
     input_json = plugin_options[0]
     idb_path = plugin_options[1]
@@ -289,10 +289,10 @@ if __name__ == '__main__':
 
     if idb_path not in selected_functions:
         print("[!] Error! IDB path (%s) not in %s" % (idb_path, input_json))
-        idc.Exit(1)
+        idaapi.qexit(1)
 
     fva_list = selected_functions[idb_path]
     print("[D] Found %d addresses" % len(fva_list))
 
     run_acfg_features(idb_path, fva_list, output_dir)
-    idc.Exit(0)
+    idaapi.qexit(0)

--- a/IDA_scripts/IDA_acfg_features/core/bb_features.py
+++ b/IDA_scripts/IDA_acfg_features/core/bb_features.py
@@ -30,7 +30,7 @@
 
 import idautils
 
-from architecture import ARCH_MNEM
+from .architecture import ARCH_MNEM
 
 
 def get_bb_strings(bb, string_list):

--- a/IDA_scripts/IDA_acfg_features/core/ff_features.py
+++ b/IDA_scripts/IDA_acfg_features/core/ff_features.py
@@ -56,6 +56,8 @@ def get_size_local_vars(fva):
     Return:
         the size of local variables
     """
+    if hasattr(idc, 'get_func_attr'):
+        return idc.get_func_attr(fva, idc.FUNCATTR_FRSIZE)
     return idc.GetFrameLvarSize(fva)
 
 

--- a/IDA_scripts/IDA_acfg_features/test_acfg_features.py
+++ b/IDA_scripts/IDA_acfg_features/test_acfg_features.py
@@ -41,13 +41,18 @@ from click.testing import CliRunner
 
 class TestIDAAcfgFeatures(unittest.TestCase):
 
+    maxDiff = None
+
     def remove_elaspesed_time(self, jd):
         """Elapsed time will be different in any run."""
         for idb, addr in jd.items():
             for va in addr:
-                if isinstance(jd[idb][va], dict) \
-                        and 'elapsed_time' in jd[idb][va]:
+                if 'elapsed_time' in jd[idb][va]:
                     jd[idb][va]['elapsed_time'] = -1
+                if 'nodes' in jd[idb][va]:
+                    jd[idb][va]['nodes'] = sorted(jd[idb][va]['nodes'])
+                if 'edges' in jd[idb][va]:
+                    jd[idb][va]['edges'] = sorted(jd[idb][va]['edges'])
         return jd
 
     def test_acfg_features(self):

--- a/IDA_scripts/IDA_acfg_features/test_large_acfg_features.py
+++ b/IDA_scripts/IDA_acfg_features/test_large_acfg_features.py
@@ -41,13 +41,18 @@ from click.testing import CliRunner
 
 class TestIDAAcfgFeatures(unittest.TestCase):
 
+    maxDiff = None
+
     def remove_elaspesed_time(self, jd):
         """Elapsed time will be different in any run."""
         for idb, addr in jd.items():
             for va in addr:
-                if isinstance(jd[idb][va], dict) \
-                        and 'elapsed_time' in jd[idb][va]:
+                if 'elapsed_time' in jd[idb][va]:
                     jd[idb][va]['elapsed_time'] = -1
+                if 'nodes' in jd[idb][va]:
+                    jd[idb][va]['nodes'] = sorted(jd[idb][va]['nodes'])
+                if 'edges' in jd[idb][va]:
+                    jd[idb][va]['edges'] = sorted(jd[idb][va]['edges'])
         return jd
 
     def test_acfg_features_large(self):

--- a/IDA_scripts/IDA_flowchart/IDA_flowchart.py
+++ b/IDA_scripts/IDA_flowchart/IDA_flowchart.py
@@ -117,7 +117,7 @@ def get_function_hashopcodes(fva):
 
     # Create a string with the opcodes
     opc_string = ''.join(opc_list)
-    opc_string = opc_string.upper()
+    opc_string = opc_string.encode('utf-8').upper()
 
     # Get the sha256 hash
     hashopcodes = hashlib.sha256(opc_string).hexdigest()
@@ -183,15 +183,15 @@ def analyze_functions(idb_path, output_csv):
 if __name__ == "__main__":
     if not idaapi.get_plugin_options("flowchart"):
         print("[!] -Oflowchart option is missing")
-        idc.Exit(1)
+        idaapi.qexit(1)
 
     plugin_options = idaapi.get_plugin_options("flowchart").split(':')
     if len(plugin_options) != 2:
         print("[!] -Oflowchart:IDB_PATH:OUTPUT_CSV is required")
-        idc.Exit(1)
+        idaapi.qexit(1)
 
     idb_path = plugin_options[0]
     output_csv = plugin_options[1]
 
     analyze_functions(idb_path, output_csv)
-    idc.Exit(0)
+    idaapi.qexit(0)


### PR DESCRIPTION
- use universal `idaapi.qexit`
- IDA 7.4+ uses `idc.get_func_attr` instead of `idc.GetFunctionAttr`[1](https://hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml)
- ensure byte/string compatibility for Python 2/3
- sort nodes/edges to help tests pass

With these changes, the unit tests for the IDA scripts pass for IDA Pro versions 7.2 - 8.1. This is using Python2 for v7.2 and Python3 for v7.4+, but they should be interchangeable.